### PR TITLE
Add `OverTheCounter` asset type

### DIFF
--- a/Regular.Polygon/Ticker/TickerType.cs
+++ b/Regular.Polygon/Ticker/TickerType.cs
@@ -15,6 +15,7 @@ public enum AssetClass
 	[EnumMember(Value = "crypto")] Crypto,
 	[EnumMember(Value = "fx")] Fx,
 	[EnumMember(Value = "indices")] Indices,
+	[EnumMember(Value = "otc")] OverTheCounter,
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }
 


### PR DESCRIPTION
This PR adds the (undocumented) `OverTheCounter` asset type to fix json deserialization.

Fixes #3 