### PR TITLE
`IPolygonApi` re-arch

### DIFF
--- a/Regular.Polygon/Distribution/Dividend.cs
+++ b/Regular.Polygon/Distribution/Dividend.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
+using Refit;
 
 namespace Regular.Polygon.Distribution;
 

--- a/Regular.Polygon/Distribution/IPolygonApi.Distribution.cs
+++ b/Regular.Polygon/Distribution/IPolygonApi.Distribution.cs
@@ -10,8 +10,7 @@ public partial interface IPolygonApi
 	/// <param name="request">Request object to hold parameters for the Stock Split api.</param>
 	/// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
 	/// <returns>The current trading status of the exchanges and overall financial markets</returns>
-	[Get("/v3/reference/splits")]
-	Task<PolygonResponse<IReadOnlyList<StockSplit>>> GetStockSplits([Query] StockSplitRequest? request = null, CancellationToken cancellationToken = default);
+	Task<PolygonResponse<IReadOnlyList<StockSplit>>> GetStockSplits(StockSplitRequest? request = null, CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Get a list of historical cash dividends, including the ticker symbol, declaration date, ex-dividend date, record date, pay date, frequency, and amount.
@@ -19,6 +18,5 @@ public partial interface IPolygonApi
 	/// <param name="request">Request object to hold parameters for the Dividend api.</param>
 	/// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
 	/// <returns>The current trading status of the exchanges and overall financial markets</returns>
-	[Get("/v3/reference/dividends")]
-	Task<PolygonResponse<IReadOnlyList<Dividend>>> GetDividends([Query] DividendRequest? request = null, CancellationToken cancellationToken = default);
+	Task<PolygonResponse<IReadOnlyList<Dividend>>> GetDividends(DividendRequest? request = null, CancellationToken cancellationToken = default);
 }

--- a/Regular.Polygon/Distribution/IPolygonApi.Internal.Distribution.cs
+++ b/Regular.Polygon/Distribution/IPolygonApi.Internal.Distribution.cs
@@ -1,0 +1,22 @@
+﻿using Refit;
+using Regular.Polygon.Distribution;
+
+namespace Regular.Polygon;
+
+internal partial class PolygonApi
+{
+	public Task<PolygonResponse<IReadOnlyList<StockSplit>>> GetStockSplits(StockSplitRequest? request = null, CancellationToken cancellationToken = default) =>
+		_refitApi.GetStockSplits(request, cancellationToken);
+
+	public Task<PolygonResponse<IReadOnlyList<Dividend>>> GetDividends(DividendRequest? request = null, CancellationToken cancellationToken = default) =>
+		_refitApi.GetDividends(request, cancellationToken);
+}
+
+internal partial interface IPolygonApiRefit
+{
+	[Get("/v3/reference/splits")]
+	Task<PolygonResponse<IReadOnlyList<StockSplit>>> GetStockSplits([Query] StockSplitRequest? request = null, CancellationToken cancellationToken = default);
+
+	[Get("/v3/reference/dividends")]
+	Task<PolygonResponse<IReadOnlyList<Dividend>>> GetDividends([Query] DividendRequest? request = null, CancellationToken cancellationToken = default);
+}

--- a/Regular.Polygon/Distribution/StockSplit.cs
+++ b/Regular.Polygon/Distribution/StockSplit.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Serialization;
+using Refit;
 
 namespace Regular.Polygon.Distribution;
 

--- a/Regular.Polygon/Financials/FinancialsRequest.cs
+++ b/Regular.Polygon/Financials/FinancialsRequest.cs
@@ -1,4 +1,6 @@
-﻿namespace Regular.Polygon.Financials;
+﻿using Refit;
+
+namespace Regular.Polygon.Financials;
 
 /// <summary>
 /// Request class to hold parameters for the Stock Financials API

--- a/Regular.Polygon/Financials/IPolygonApi.Financials.cs
+++ b/Regular.Polygon/Financials/IPolygonApi.Financials.cs
@@ -13,6 +13,5 @@ public partial interface IPolygonApi
 	/// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
 	/// <returns>A list of company SEC filings.</returns>
 	/// <remarks>This API is experimental</remarks>
-	[Get("/vX/reference/financials")]
-	Task<PolygonResponse<IReadOnlyList<FinancialsFiling>>> GetStockFinancials([Query] FinancialsRequest request, CancellationToken cancellationToken = default);
+	Task<PolygonResponse<IReadOnlyList<FinancialsFiling>>> GetStockFinancials(FinancialsRequest request, CancellationToken cancellationToken = default);
 }

--- a/Regular.Polygon/Financials/IPolygonApi.Internal.Financials.cs
+++ b/Regular.Polygon/Financials/IPolygonApi.Internal.Financials.cs
@@ -1,0 +1,16 @@
+﻿using Refit;
+using Regular.Polygon.Financials;
+
+namespace Regular.Polygon;
+
+internal partial class PolygonApi
+{
+	public Task<PolygonResponse<IReadOnlyList<FinancialsFiling>>> GetStockFinancials([Query] FinancialsRequest request, CancellationToken cancellationToken = default) =>
+		_refitApi.GetStockFinancials(request, cancellationToken);
+}
+
+internal partial interface IPolygonApiRefit
+{
+	[Get("/vX/reference/financials")]
+	Task<PolygonResponse<IReadOnlyList<FinancialsFiling>>> GetStockFinancials([Query] FinancialsRequest request, CancellationToken cancellationToken = default);
+}

--- a/Regular.Polygon/IPolygonApi.cs
+++ b/Regular.Polygon/IPolygonApi.cs
@@ -1,6 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Web;
 using CommunityToolkit.Diagnostics;
-using System.Web;
 
 namespace Regular.Polygon;
 
@@ -21,6 +20,16 @@ public partial interface IPolygonApi
 			new UnixMillisecondDateTimeOffsetConverter(),
 		},
 	};
+}
+
+internal sealed partial class PolygonApi : IPolygonApi
+{
+	private readonly IPolygonApiRefit _refitApi;
+
+	public PolygonApi(IPolygonApiRefit refitApi)
+	{
+		_refitApi = refitApi;
+	}
 
 	private static async Task<IReadOnlyList<T>> GetFullList<T>(
 		Task<PolygonResponse<IReadOnlyList<T>>> responseTask,
@@ -46,4 +55,9 @@ public partial interface IPolygonApi
 
 		return list.ToList();
 	}
+}
+
+internal partial interface IPolygonApiRefit
+{
+
 }

--- a/Regular.Polygon/Market/IPolygonApi.Internal.Market.cs
+++ b/Regular.Polygon/Market/IPolygonApi.Internal.Market.cs
@@ -1,0 +1,22 @@
+﻿using Refit;
+using Regular.Polygon.Market;
+
+namespace Regular.Polygon;
+
+internal partial class PolygonApi
+{
+	public Task<MarketStatus> GetMarketStatus(CancellationToken cancellationToken = default) =>
+		_refitApi.GetMarketStatus(cancellationToken);
+
+	public Task<IReadOnlyList<MarketHoliday>> GetMarketHolidays(CancellationToken cancellationToken = default) =>
+		_refitApi.GetMarketHolidays(cancellationToken);
+}
+
+internal partial interface IPolygonApiRefit
+{
+	[Get("/v1/marketstatus/now")]
+	Task<MarketStatus> GetMarketStatus(CancellationToken cancellationToken = default);
+
+	[Get("/v1/marketstatus/upcoming")]
+	Task<IReadOnlyList<MarketHoliday>> GetMarketHolidays(CancellationToken cancellationToken = default);
+}

--- a/Regular.Polygon/Market/IPolygonApi.Market.cs
+++ b/Regular.Polygon/Market/IPolygonApi.Market.cs
@@ -9,7 +9,6 @@ public partial interface IPolygonApi
 	/// </summary>
 	/// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
 	/// <returns>The current trading status of the exchanges and overall financial markets</returns>
-	[Get("/v1/marketstatus/now")]
 	Task<MarketStatus> GetMarketStatus(CancellationToken cancellationToken = default);
 
 	/// <summary>
@@ -17,6 +16,5 @@ public partial interface IPolygonApi
 	/// </summary>
 	/// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
 	/// <returns>A list of the upcoming market holidays</returns>
-	[Get("/v1/marketstatus/upcoming")]
 	Task<IReadOnlyList<MarketHoliday>> GetMarketHolidays(CancellationToken cancellationToken = default);
 }

--- a/Regular.Polygon/PolygonServiceCollectionExtensions.cs
+++ b/Regular.Polygon/PolygonServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
+using Refit;
 
 namespace Regular.Polygon;
 
@@ -24,7 +25,7 @@ public static class PolygonServiceCollectionExtensions
 		services.Configure<PolygonOptions>(o => o.ApiKey = apiKey);
 		services.AddTransient<PolygonMessageHandler>();
 		services
-			.AddRefitClient<IPolygonApi>(settings: new()
+			.AddRefitClient<IPolygonApiRefit>(settings: new()
 			{
 				ContentSerializer = new SystemTextJsonContentSerializer(IPolygonApi.DefaultSerializerOptions),
 				UrlParameterFormatter = new UrlParameterFormatter(),
@@ -33,6 +34,7 @@ public static class PolygonServiceCollectionExtensions
 			.ConfigurePrimaryHttpMessageHandler(() =>
 				new HttpClientHandler { AutomaticDecompression = System.Net.DecompressionMethods.All, })
 			.AddHttpMessageHandler<PolygonMessageHandler>();
+		services.AddSingleton<IPolygonApi, PolygonApi>();
 
 		return services;
 	}

--- a/Regular.Polygon/Regular.Polygon.csproj
+++ b/Regular.Polygon/Regular.Polygon.csproj
@@ -29,7 +29,6 @@
 		<Using Include="Microsoft.Extensions.Configuration" />
 		<Using Include="Microsoft.Extensions.Options" />
 		<Using Include="Microsoft.Extensions.Logging" />
-		<Using Include="Refit" />
 		<Using Include="System.Text.Json" />
 	</ItemGroup>
 

--- a/Regular.Polygon/Ticker/IPolygonApi.Internal.Tickers.cs
+++ b/Regular.Polygon/Ticker/IPolygonApi.Internal.Tickers.cs
@@ -1,0 +1,37 @@
+﻿using Refit;
+using Regular.Polygon.Ticker;
+
+namespace Regular.Polygon;
+
+internal partial class PolygonApi
+{
+	public Task<PolygonResponse<IReadOnlyList<TickerType>>> GetTickerTypes(TickerTypeRequest? request = null, CancellationToken cancellationToken = default) =>
+		_refitApi.GetTickerTypes(request, cancellationToken);
+
+	public Task<PolygonResponse<IReadOnlyList<TickerSearchResult>>> SearchTickers(TickerSearchRequest? request = null, CancellationToken cancellationToken = default) =>
+		_refitApi.SearchTickers(request, cancellationToken);
+
+	public Task<PolygonResponse<IReadOnlyList<TickerSearchResult>>> SearchTickersCursor(string cursor, CancellationToken cancellationToken = default) =>
+		_refitApi.SearchTickersCursor(cursor, cancellationToken);
+
+	public Task<IReadOnlyList<TickerSearchResult>> SearchTickersAll(TickerSearchRequest? request = null, CancellationToken cancellationToken = default) =>
+		GetFullList(SearchTickers(request, cancellationToken), SearchTickersCursor, cancellationToken);
+
+	public Task<PolygonResponse<TickerDetail>> GetTickerDetails(string ticker, DateOnly? date = null, CancellationToken cancellationToken = default) =>
+		_refitApi.GetTickerDetails(ticker, date, cancellationToken);
+}
+
+internal partial interface IPolygonApiRefit
+{
+	[Get("/v3/reference/tickers/types")]
+	Task<PolygonResponse<IReadOnlyList<TickerType>>> GetTickerTypes([Query] TickerTypeRequest? request = null, CancellationToken cancellationToken = default);
+
+	[Get("/v3/reference/tickers")]
+	Task<PolygonResponse<IReadOnlyList<TickerSearchResult>>> SearchTickers([Query] TickerSearchRequest? request = null, CancellationToken cancellationToken = default);
+
+	[Get("/v3/reference/tickers")]
+	Task<PolygonResponse<IReadOnlyList<TickerSearchResult>>> SearchTickersCursor([Query] string cursor, CancellationToken cancellationToken = default);
+
+	[Get("/v3/reference/tickers/{ticker}")]
+	Task<PolygonResponse<TickerDetail>> GetTickerDetails(string ticker, [Query] DateOnly? date = null, CancellationToken cancellationToken = default);
+}

--- a/Regular.Polygon/Ticker/IPolygonApi.Tickers.cs
+++ b/Regular.Polygon/Ticker/IPolygonApi.Tickers.cs
@@ -10,8 +10,7 @@ public partial interface IPolygonApi
 	/// <param name="request">Request object to hold parameters for the Ticker Types api.</param>
 	/// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
 	/// <returns>A list of supported ticker types matching the parameters.</returns>
-	[Get("/v3/reference/tickers/types")]
-	Task<PolygonResponse<IReadOnlyList<TickerType>>> GetTickerTypes([Query] TickerTypeRequest? request = null, CancellationToken cancellationToken = default);
+	Task<PolygonResponse<IReadOnlyList<TickerType>>> GetTickerTypes(TickerTypeRequest? request = null, CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Query all ticker symbols which are supported by Polygon.io. This API currently includes Stocks/Equities, Indices, Forex, and Crypto.
@@ -19,18 +18,7 @@ public partial interface IPolygonApi
 	/// <param name="request">Request object to hold parameters for the Ticker Search api.</param>
 	/// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
 	/// <returns>A list of tickers matching the query.</returns>
-	[Get("/v3/reference/tickers")]
-	Task<PolygonResponse<IReadOnlyList<TickerSearchResult>>> SearchTickers([Query] TickerSearchRequest? request = null, CancellationToken cancellationToken = default);
-
-	/// <summary>
-	/// Retrieve a subsequent page for a <see cref="SearchTickers(TickerSearchRequest?,CancellationToken)"/> response
-	/// that had additional information.
-	/// </summary>
-	/// <param name="cursor">The cursor provided by polygon.io for the next page</param>
-	/// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
-	/// <returns>The next page of tickers matching the original query.</returns>
-	[Get("/v3/reference/tickers")]
-	Task<PolygonResponse<IReadOnlyList<TickerSearchResult>>> SearchTickersCursor([Query] string cursor, CancellationToken cancellationToken = default);
+	Task<PolygonResponse<IReadOnlyList<TickerSearchResult>>> SearchTickers(TickerSearchRequest? request = null, CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Query all ticker symbols which are supported by Polygon.io. This API currently includes Stocks/Equities, Indices, Forex, and Crypto.
@@ -38,8 +26,7 @@ public partial interface IPolygonApi
 	/// <param name="request">Request object to hold parameters for the Ticker Search api.</param>
 	/// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
 	/// <returns>A list of tickers matching the query.</returns>
-	public Task<IReadOnlyList<TickerSearchResult>> SearchTickersAll(TickerSearchRequest? request = null, CancellationToken cancellationToken = default) =>
-		GetFullList(SearchTickers(request, cancellationToken), SearchTickersCursor, cancellationToken);
+	public Task<IReadOnlyList<TickerSearchResult>> SearchTickersAll(TickerSearchRequest? request = null, CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Get a single ticker supported by Polygon.io. This response will have detailed information about the ticker and the company behind it.
@@ -62,6 +49,5 @@ public partial interface IPolygonApi
 	/// </param>
 	/// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
 	/// <returns>Detailed information on a Ticker</returns>
-	[Get("/v3/reference/tickers/{ticker}")]
-	Task<PolygonResponse<TickerDetail>> GetTickerDetails(string ticker, [Query] DateOnly? date = null, CancellationToken cancellationToken = default);
+	Task<PolygonResponse<TickerDetail>> GetTickerDetails(string ticker, DateOnly? date = null, CancellationToken cancellationToken = default);
 }

--- a/Regular.Polygon/Ticker/TickerSearch.cs
+++ b/Regular.Polygon/Ticker/TickerSearch.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Serialization;
+using Refit;
 
 namespace Regular.Polygon.Ticker;
 

--- a/Regular.Polygon/Ticker/TickerType.cs
+++ b/Regular.Polygon/Ticker/TickerType.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
+using Refit;
 
 namespace Regular.Polygon.Ticker;
 

--- a/Regular.Polygon/Trades/Aggregate.cs
+++ b/Regular.Polygon/Trades/Aggregate.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
+using Refit;
 
 namespace Regular.Polygon.Trades;
 

--- a/Regular.Polygon/Trades/IPolygonApi.Internal.Trades.cs
+++ b/Regular.Polygon/Trades/IPolygonApi.Internal.Trades.cs
@@ -1,0 +1,126 @@
+﻿using Refit;
+using Regular.Polygon.Trades;
+
+namespace Regular.Polygon;
+
+internal partial class PolygonApi
+{
+	public Task<AggregateResponse> GetAggregateBars(
+		string ticker,
+		int multiplier,
+		Timespan timespan,
+		DateTimeOffset from,
+		DateTimeOffset to,
+		AggregateRequest? request = null,
+		CancellationToken cancellationToken = default) =>
+		GetAggregateBars(
+			ticker,
+			multiplier,
+			timespan,
+			from.ToUnixTimeMilliseconds(),
+			to.ToUnixTimeMilliseconds(),
+			request,
+			cancellationToken);
+
+	public Task<AggregateResponse> GetAggregateBars(
+		string ticker,
+		int multiplier,
+		Timespan timespan,
+		DateOnly from,
+		DateOnly to,
+		AggregateRequest? request = null,
+		CancellationToken cancellationToken = default) =>
+		_refitApi.GetAggregateBars(ticker, multiplier, timespan, from, to, request, cancellationToken);
+
+	public Task<AggregateResponse> GetAggregateBars(
+		string ticker,
+		int multiplier,
+		Timespan timespan,
+		long from,
+		long to,
+		AggregateRequest? request = null,
+		CancellationToken cancellationToken = default) =>
+		_refitApi.GetAggregateBars(ticker, multiplier, timespan, from, to, request, cancellationToken);
+
+	public Task<DailyPrice> GetDailyPrice(
+		string ticker,
+		DateOnly date,
+		bool? adjusted = null,
+		CancellationToken cancellationToken = default) =>
+		_refitApi.GetDailyPrice(ticker, date, adjusted, cancellationToken);
+
+	public Task<PolygonResponse<IReadOnlyList<AggregateBar>>> GetPreviousDailyPrice(
+		string ticker,
+		bool? adjusted = null,
+		CancellationToken cancellationToken = default) =>
+		_refitApi.GetPreviousDailyPrice(ticker, adjusted, cancellationToken);
+
+	public Task<PolygonResponse<IReadOnlyList<Trade>>> GetTrades(
+		string ticker,
+		TradesRequest request,
+		CancellationToken cancellationToken = default) =>
+		_refitApi.GetTrades(ticker, request, cancellationToken);
+
+	public Task<PolygonResponse<IReadOnlyList<Trade>>> GetTradesCursor(
+		string ticker,
+		string cursor,
+		CancellationToken cancellationToken = default) =>
+		_refitApi.GetTradesCursor(ticker, cursor, cancellationToken);
+
+	public Task<IReadOnlyList<Trade>> GetTradesAll(
+		string ticker,
+		TradesRequest request,
+		CancellationToken cancellationToken = default) =>
+		GetFullList(
+			GetTrades(ticker, request, cancellationToken),
+			(c, ct) => GetTradesCursor(ticker, c, ct),
+			cancellationToken);
+}
+
+internal partial interface IPolygonApiRefit
+{
+	[Get("/v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from}/{to}")]
+	Task<AggregateResponse> GetAggregateBars(
+		string ticker,
+		int multiplier,
+		Timespan timespan,
+		DateOnly from,
+		DateOnly to,
+		[Query] AggregateRequest? request = null,
+		CancellationToken cancellationToken = default);
+
+	[Get("/v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from}/{to}")]
+	Task<AggregateResponse> GetAggregateBars(
+		string ticker,
+		int multiplier,
+		Timespan timespan,
+		long from,
+		long to,
+		[Query] AggregateRequest? request = null,
+		CancellationToken cancellationToken = default);
+
+	[Get("/v1/open-close/{ticker}/{date}")]
+	Task<DailyPrice> GetDailyPrice(
+		string ticker,
+		DateOnly date,
+		bool? adjusted = null,
+		CancellationToken cancellationToken = default);
+
+	[Get("/v2/aggs/ticker/{ticker}/prev")]
+	Task<PolygonResponse<IReadOnlyList<AggregateBar>>> GetPreviousDailyPrice(
+		string ticker,
+		bool? adjusted = null,
+		CancellationToken cancellationToken = default);
+
+	[Get("/v3/trades/{ticker}")]
+	Task<PolygonResponse<IReadOnlyList<Trade>>> GetTrades(
+		string ticker,
+		TradesRequest request,
+		CancellationToken cancellationToken = default);
+
+	[Get("/v3/trades/{ticker}")]
+	Task<PolygonResponse<IReadOnlyList<Trade>>> GetTradesCursor(
+		string ticker,
+		[Query] string cursor,
+		CancellationToken cancellationToken = default);
+}

--- a/Regular.Polygon/Trades/IPolygonApi.Trades.cs
+++ b/Regular.Polygon/Trades/IPolygonApi.Trades.cs
@@ -29,46 +29,7 @@ public partial interface IPolygonApi
 		Timespan timespan,
 		DateTimeOffset from,
 		DateTimeOffset to,
-		[Query] AggregateRequest? request = null,
-		CancellationToken cancellationToken = default)
-	{
-		return GetAggregateBars(
-			ticker,
-			multiplier,
-			timespan,
-			from.ToUnixTimeMilliseconds(),
-			to.ToUnixTimeMilliseconds(),
-			request,
-			cancellationToken);
-	}
-
-	/// <summary>
-	/// Get aggregate bars for a stock over a given date range in custom time window sizes.
-	/// </summary>
-	/// <remarks>
-	/// For example, if <paramref name="timespan"/> = <see cref="Timespan.Minute"/> and <paramref name="multiplier"/> =
-	/// <c>5</c> then 5-minute bars will be returned.
-	/// </remarks>
-	/// <param name="ticker">The ticker symbol of the security.</param>
-	/// <param name="multiplier">The size of the time window.</param>
-	/// <param name="timespan">The size of the time window.</param>
-	/// <param name="from">The start of the aggregate time window.</param>
-	/// <param name="to">The end of the aggregate time window.</param>
-	/// <param name="request">Request object to hold additional parameters for the Aggregates api.</param>
-	/// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
-	/// <returns>A list of the OHLC bars for the time windows requested.</returns>
-	/// <remarks>
-	/// Read more about how aggregate results are calculated in our article on <a
-	/// href="https://polygon.io/blog/aggs-api-updates/">Aggregate Data API Improvements</a>.
-	/// </remarks>
-	[Get("/v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from}/{to}")]
-	Task<AggregateResponse> GetAggregateBars(
-		string ticker,
-		int multiplier,
-		Timespan timespan,
-		DateOnly from,
-		DateOnly to,
-		[Query] AggregateRequest? request = null,
+		AggregateRequest? request = null,
 		CancellationToken cancellationToken = default);
 
 	/// <summary>
@@ -90,14 +51,41 @@ public partial interface IPolygonApi
 	/// Read more about how aggregate results are calculated in our article on <a
 	/// href="https://polygon.io/blog/aggs-api-updates/">Aggregate Data API Improvements</a>.
 	/// </remarks>
-	[Get("/v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from}/{to}")]
+	Task<AggregateResponse> GetAggregateBars(
+		string ticker,
+		int multiplier,
+		Timespan timespan,
+		DateOnly from,
+		DateOnly to,
+		AggregateRequest? request = null,
+		CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Get aggregate bars for a stock over a given date range in custom time window sizes.
+	/// </summary>
+	/// <remarks>
+	/// For example, if <paramref name="timespan"/> = <see cref="Timespan.Minute"/> and <paramref name="multiplier"/> =
+	/// <c>5</c> then 5-minute bars will be returned.
+	/// </remarks>
+	/// <param name="ticker">The ticker symbol of the security.</param>
+	/// <param name="multiplier">The size of the time window.</param>
+	/// <param name="timespan">The size of the time window.</param>
+	/// <param name="from">The start of the aggregate time window.</param>
+	/// <param name="to">The end of the aggregate time window.</param>
+	/// <param name="request">Request object to hold additional parameters for the Aggregates api.</param>
+	/// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
+	/// <returns>A list of the OHLC bars for the time windows requested.</returns>
+	/// <remarks>
+	/// Read more about how aggregate results are calculated in our article on <a
+	/// href="https://polygon.io/blog/aggs-api-updates/">Aggregate Data API Improvements</a>.
+	/// </remarks>
 	Task<AggregateResponse> GetAggregateBars(
 		string ticker,
 		int multiplier,
 		Timespan timespan,
 		long from,
 		long to,
-		[Query] AggregateRequest? request = null,
+		AggregateRequest? request = null,
 		CancellationToken cancellationToken = default);
 
 	/// <summary>
@@ -109,7 +97,6 @@ public partial interface IPolygonApi
 	/// this to <see langword="false"/> to get results that are NOT adjusted for splits.</param>
 	/// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
 	/// <returns>The open, close and afterhours prices of a ticker on a certain date.</returns>
-	[Get("/v1/open-close/{ticker}/{date}")]
 	Task<DailyPrice> GetDailyPrice(
 		string ticker,
 		DateOnly date,
@@ -124,7 +111,6 @@ public partial interface IPolygonApi
 	/// this to <see langword="false"/> to get results that are NOT adjusted for splits.</param>
 	/// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
 	/// <returns>The open, close and afterhours prices of a ticker of the previous trading day.</returns>
-	[Get("/v2/aggs/ticker/{ticker}/prev")]
 	Task<PolygonResponse<IReadOnlyList<AggregateBar>>> GetPreviousDailyPrice(
 		string ticker,
 		bool? adjusted = null,
@@ -137,23 +123,9 @@ public partial interface IPolygonApi
 	/// <param name="request">Request object to hold additional parameters for the Trades api.</param>
 	/// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
 	/// <returns>A list of the trades that occurred during the given time range.</returns>
-	[Get("/v3/trades/{ticker}")]
 	Task<PolygonResponse<IReadOnlyList<Trade>>> GetTrades(
 		string ticker,
 		TradesRequest request,
-		CancellationToken cancellationToken = default);
-
-	/// <summary>
-	/// Get trades for a ticker symbol in a given time range.
-	/// </summary>
-	/// <param name="ticker">The ticker symbol of the security.</param>
-	/// <param name="cursor">The cursor provided by polygon.io for the next page</param>
-	/// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
-	/// <returns>A list of the trades that occurred during the given time range.</returns>
-	[Get("/v3/trades/{ticker}")]
-	Task<PolygonResponse<IReadOnlyList<Trade>>> GetTradesCursor(
-		string ticker,
-		[Query] string cursor,
 		CancellationToken cancellationToken = default);
 
 	/// <summary>
@@ -166,11 +138,5 @@ public partial interface IPolygonApi
 	Task<IReadOnlyList<Trade>> GetTradesAll(
 		string ticker,
 		TradesRequest request,
-		CancellationToken cancellationToken = default)
-	{
-		return GetFullList(
-			GetTrades(ticker, request, cancellationToken),
-			(c, ct) => GetTradesCursor(ticker, c, ct),
-			cancellationToken);
-	}
+		CancellationToken cancellationToken = default);
 }

--- a/Regular.Polygon/Trades/Trades.cs
+++ b/Regular.Polygon/Trades/Trades.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
+using Refit;
 
 namespace Regular.Polygon.Trades;
 

--- a/Regular.Polygon/UrlParameterFormatter.cs
+++ b/Regular.Polygon/UrlParameterFormatter.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Refit;
 
 namespace Regular.Polygon;
 


### PR DESCRIPTION
This PR adds `PolygonApi` and `IPolygonApiRefit` to rearchitect the library internals. This allows methods on the `IPolygonApi` that cannot be supported by a refit API, such as the upcoming websocket methods.